### PR TITLE
feat: avoid emitting value change event onSubmit

### DIFF
--- a/projects/ng-bootstrap-form-validation/src/lib/Directives/form-validation.directive.spec.ts
+++ b/projects/ng-bootstrap-form-validation/src/lib/Directives/form-validation.directive.spec.ts
@@ -1,8 +1,55 @@
 import { FormValidationDirective } from "./form-validation.directive";
+import {FormControl, FormControlStatus, FormGroup} from "@angular/forms";
+import {EventEmitter} from "@angular/core";
 
 describe("FormGroupDirective", () => {
   it("should create an instance", () => {
     const directive = new FormValidationDirective();
     expect(directive).toBeTruthy();
+  });
+
+  describe("updateValueAndValiditySilent", () => {
+    let control: FormControl;
+    const directive = new FormValidationDirective();
+
+    beforeEach(() => {
+      control = new FormControl("name");
+    });
+
+    it("call updateValueAndValidity without event emit", () => {
+      spyOn(control, "updateValueAndValidity");
+
+      directive.updateValueAndValiditySilent(control);
+
+      expect(control.updateValueAndValidity).toHaveBeenCalledOnceWith({ emitEvent: false });
+    });
+
+    it("emits status change event", () => {
+      const spyEmitStatusChanges = spyOn((control.statusChanges as EventEmitter<FormControlStatus>), "emit");
+
+      directive.updateValueAndValiditySilent(control);
+
+      expect(spyEmitStatusChanges).toHaveBeenCalledOnceWith("VALID");
+    });
+
+    it("does not emit value change event", () => {
+      const spyValueChanges = spyOn((control.valueChanges as EventEmitter<any>), "emit");
+
+      directive.updateValueAndValiditySilent(control);
+
+      expect(spyValueChanges).not.toHaveBeenCalled();
+    });
+
+    it("call the updateValueAndValiditySilent for the parent", () => {
+      const parent = new FormGroup({});
+      control.setParent(parent);
+      const spyUpdateValueAndValiditySilent = spyOn(directive, "updateValueAndValiditySilent").and.callThrough();
+
+      directive.updateValueAndValiditySilent(control);
+
+      expect(spyUpdateValueAndValiditySilent).toHaveBeenCalledTimes(2);
+      expect(spyUpdateValueAndValiditySilent).toHaveBeenCalledWith(control);
+      expect(spyUpdateValueAndValiditySilent).toHaveBeenCalledWith(parent);
+    });
   });
 });

--- a/projects/ng-bootstrap-form-validation/src/lib/Directives/form-validation.directive.spec.ts
+++ b/projects/ng-bootstrap-form-validation/src/lib/Directives/form-validation.directive.spec.ts
@@ -8,7 +8,7 @@ describe("FormGroupDirective", () => {
     expect(directive).toBeTruthy();
   });
 
-  describe("updateValueAndValiditySilent", () => {
+  describe("updateValueAndValiditySilently", () => {
     let control: FormControl;
     const directive = new FormValidationDirective();
 
@@ -16,10 +16,10 @@ describe("FormGroupDirective", () => {
       control = new FormControl("name");
     });
 
-    it("call updateValueAndValidity without event emit", () => {
+    it("calls updateValueAndValidity without event emit", () => {
       spyOn(control, "updateValueAndValidity");
 
-      directive.updateValueAndValiditySilent(control);
+      directive.updateValueAndValiditySilently(control);
 
       expect(control.updateValueAndValidity).toHaveBeenCalledOnceWith({ emitEvent: false });
     });
@@ -27,7 +27,7 @@ describe("FormGroupDirective", () => {
     it("emits status change event", () => {
       const spyEmitStatusChanges = spyOn((control.statusChanges as EventEmitter<FormControlStatus>), "emit");
 
-      directive.updateValueAndValiditySilent(control);
+      directive.updateValueAndValiditySilently(control);
 
       expect(spyEmitStatusChanges).toHaveBeenCalledOnceWith("VALID");
     });
@@ -35,7 +35,7 @@ describe("FormGroupDirective", () => {
     it("does not emit value change event", () => {
       const spyValueChanges = spyOn((control.valueChanges as EventEmitter<any>), "emit");
 
-      directive.updateValueAndValiditySilent(control);
+      directive.updateValueAndValiditySilently(control);
 
       expect(spyValueChanges).not.toHaveBeenCalled();
     });
@@ -43,9 +43,9 @@ describe("FormGroupDirective", () => {
     it("call the updateValueAndValiditySilent for the parent", () => {
       const parent = new FormGroup({});
       control.setParent(parent);
-      const spyUpdateValueAndValiditySilent = spyOn(directive, "updateValueAndValiditySilent").and.callThrough();
+      const spyUpdateValueAndValiditySilent = spyOn(directive, "updateValueAndValiditySilently").and.callThrough();
 
-      directive.updateValueAndValiditySilent(control);
+      directive.updateValueAndValiditySilently(control);
 
       expect(spyUpdateValueAndValiditySilent).toHaveBeenCalledTimes(2);
       expect(spyUpdateValueAndValiditySilent).toHaveBeenCalledWith(control);

--- a/projects/ng-bootstrap-form-validation/src/lib/Directives/form-validation.directive.ts
+++ b/projects/ng-bootstrap-form-validation/src/lib/Directives/form-validation.directive.ts
@@ -8,7 +8,7 @@ import {
 import {
   AbstractControl,
   FormArray,
-  FormControl,
+  FormControl, FormControlStatus,
   FormGroup
 } from "@angular/forms";
 
@@ -40,7 +40,25 @@ export class FormValidationDirective {
     } else if (control instanceof FormControl && control.enabled) {
       control.markAsDirty();
       control.markAsTouched();
-      control.updateValueAndValidity();
+      this.updateValueAndValiditySilent(control);
+    }
+  }
+
+  /**
+   * Custom function for updating the value and validity of a control without triggering a value change event.
+   * The implementation does the following:
+   *  - calls the standard `AbstractControl.updateValueAndValidity` without emitting events
+   *  - manually emit the statusChange event
+   *  - call the same method for the parent, if defined
+   * @see angular implementation: https://github.com/angular/angular/blob/main/packages/forms/src/model/abstract_model.ts#L1045
+   * @fixes https://redmine.kwsoft.ch/issues/14376
+   */
+  updateValueAndValiditySilent(control: AbstractControl) {
+    control.updateValueAndValidity({emitEvent: false});
+
+    (control.statusChanges as EventEmitter<FormControlStatus>).emit(control.status);
+    if (control.parent) {
+      this.updateValueAndValiditySilent(control.parent);
     }
   }
 }

--- a/projects/ng-bootstrap-form-validation/src/lib/Directives/form-validation.directive.ts
+++ b/projects/ng-bootstrap-form-validation/src/lib/Directives/form-validation.directive.ts
@@ -40,7 +40,7 @@ export class FormValidationDirective {
     } else if (control instanceof FormControl && control.enabled) {
       control.markAsDirty();
       control.markAsTouched();
-      this.updateValueAndValiditySilent(control);
+      this.updateValueAndValiditySilently(control);
     }
   }
 
@@ -53,12 +53,12 @@ export class FormValidationDirective {
    * @see angular implementation: https://github.com/angular/angular/blob/main/packages/forms/src/model/abstract_model.ts#L1045
    * @fixes https://redmine.kwsoft.ch/issues/14376
    */
-  updateValueAndValiditySilent(control: AbstractControl) {
+  updateValueAndValiditySilently(control: AbstractControl) {
     control.updateValueAndValidity({emitEvent: false});
 
     (control.statusChanges as EventEmitter<FormControlStatus>).emit(control.status);
     if (control.parent) {
-      this.updateValueAndValiditySilent(control.parent);
+      this.updateValueAndValiditySilently(control.parent);
     }
   }
 }


### PR DESCRIPTION
- use custom function for updating the control validity on submit. The function calls the standard angular `AbstractControl.updateValueAndValidity({emitEvent: false})` and after it emits a status change.

refs #14376